### PR TITLE
add server response statistics (API)

### DIFF
--- a/admin-scripts/package-lock.json
+++ b/admin-scripts/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "siros-postgres",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/admin-scripts/package.json
+++ b/admin-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siros-postgres",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Siros admin scripts (command line)",
   "dependencies": {
     "dotenv": "^6.1.0",

--- a/api-server/lib/api-stats.js
+++ b/api-server/lib/api-stats.js
@@ -1,0 +1,22 @@
+const dependency = {
+  stats: null,
+};
+
+module.exports = [
+  {
+    name: 'get/api-stats',
+    setDependencies: (deps) => { dependency.stats = deps.stats; },
+    path: '/stats',
+    method: 'get',
+    handler: (ctx) => {
+      if (dependency.stats) {
+        ctx.body = dependency.stats.get(
+          ctx.request.query.recent && (ctx.request.query.recent === 'true'),
+          ctx.request.query.reset && (ctx.request.query.reset === 'true'),
+        );
+      } else {
+        ctx.status = 500;
+      }
+    },
+  },
+];

--- a/api-server/lib/api.js
+++ b/api-server/lib/api.js
@@ -2,24 +2,40 @@ const apiMe = require('./api-me');
 const apiHwList = require('./api-hw-list');
 const apiHwBudget = require('./api-hw-budget');
 const apiMarketplace = require('./api-marketplace');
+const apiStats = require('./api-stats');
 
 const PREFIX = '/api/v1';
+const dependencyRouter = {};
 
 const install = (router, logger, array) => {
   array.forEach((def) => {
     const path = `${PREFIX}${def.path}`;
     logger.debug(`router config: registering handler HTTP method ${def.method.toUpperCase()} and endpoint ${path}`);
     router[def.method](path, def.handler);
+    if (def.name && def.setDependencies) { dependencyRouter[def.name] = def.setDependencies; }
+  });
+};
+
+const addRoutes = (router, logger) => {
+  const inst = install.bind(null, router, logger);
+  inst(apiMe);
+  inst(apiHwList);
+  inst(apiHwBudget);
+  inst(apiMarketplace);
+  inst(apiStats);
+};
+
+const setDependencies = (dependencyObj) => {
+  Object.keys(dependencyObj).forEach((moduleName) => {
+    const fn = dependencyRouter[moduleName];
+    if (fn) { fn(dependencyObj[moduleName]); }
   });
 };
 
 module.exports = {
-  addRoutes: (router, logger) => {
-    const inst = install.bind(null, router, logger);
-    inst(apiMe);
-    inst(apiHwList);
-    inst(apiHwBudget);
-    inst(apiMarketplace);
+  API: {
+    addRoutes,
+    setDependencies,
+    PREFIX,
   },
-  PREFIX,
 };

--- a/api-server/lib/auth.js
+++ b/api-server/lib/auth.js
@@ -1,6 +1,6 @@
 const passport = require('koa-passport');
 const GoogleStrategy = require('passport-google-oauth20').Strategy;
-const API_PREFIX = require('./api').PREFIX;
+const API_PREFIX = require('./api').API.PREFIX;
 
 const CLIENT_ROUTES = {
   default: '/',
@@ -72,6 +72,8 @@ const addRoutes = (router, config) => {
 };
 
 module.exports = {
-  install,
-  addRoutes,
+  Auth: {
+    install,
+    addRoutes,
+  },
 };

--- a/api-server/lib/config.js
+++ b/api-server/lib/config.js
@@ -21,4 +21,6 @@ const config = {
 // dynamic adjustments
 if (process.env.NODE_ENV === 'development') { config.logLevel = 'debug'; }
 
-module.exports = config;
+module.exports = {
+  config,
+};

--- a/api-server/lib/db-query.js
+++ b/api-server/lib/db-query.js
@@ -153,4 +153,6 @@ class DbQuery extends Db {
   }
 }
 
-module.exports = DbQuery;
+module.exports = {
+  DbQuery,
+};

--- a/api-server/lib/logger.js
+++ b/api-server/lib/logger.js
@@ -13,23 +13,6 @@ const create = (config) => {
   return logger;
 };
 
-// koa middleware to log request / response exchange at top level
-const logReqResp = async (logger, ctx, next) => {
-  const start = Date.now();
-  logger.info(`--> ${ctx.method} ${ctx.url}`);
-  logger.debug(`*** request headers: ${JSON.stringify(ctx.request.header, null, 2)}`);
-  await next();
-  if (ctx.body) {
-    const data = ctx.response.header['content-encoding'] === 'gzip'
-      ? '< ... gzip ... >'
-      : JSON.stringify(ctx.body, null, 2);
-    logger.debug(`*** response body: ${data}`);
-  }
-  logger.debug(`*** response headers: ${JSON.stringify(ctx.response.header, null, 2)}`);
-  logger.info(`<-- ${ctx.status} in ${Date.now() - start}ms`);
-};
-
 module.exports = {
   create,
-  logReqResp,
 };

--- a/api-server/lib/stats.js
+++ b/api-server/lib/stats.js
@@ -1,0 +1,174 @@
+class StatefulRingBuffer {
+  // maxSize: how many recent items to keep, when 0 (default, no items) `cbOut` callback is NEVER invoked
+  // initialState: object holding the stats to be updated with each items going in/out the buffer
+  // cbIn: reducer updating the state when an item is entering the buffer
+  // cbOut: reducer updating the state when an item is leaving the buffer
+  constructor(maxSize = 0, initialState = {}, cbIn = (state) => (state), cbOut = (state) => (state)) {
+    this.maxSize = maxSize;
+    this.size = 0;
+    this.head = null;
+    this.tail = null;
+    this.state = initialState;
+    this.callbacks = { in: cbIn, out: cbOut };
+  }
+
+  push(item) {
+    this.state = this.callbacks.in(this.state, item);
+    if (this.maxSize < 1) { return; }
+    if (this.size < this.maxSize) {
+      const element = {
+        item,
+        prev: null,
+      };
+      if (!this.head) {
+        this.head = element;
+        this.tail = element;
+      } else {
+        this.head.prev = element;
+        this.head = element;
+      }
+      this.size += 1;
+      if (this.size === this.maxSize) {
+        this.head.prev = this.tail;
+      }
+    } else {
+      this.state = this.callbacks.out(this.state, this.tail.item);
+      this.head = this.tail;
+      this.tail = this.tail.prev;
+      this.head.item = item;
+    }
+  }
+
+  getState(includeItems = false) {
+    if (!includeItems) { return { ...(this.state) }; }
+    const arr = [];
+    let ptr = this.tail;
+    for (let i = 0; i < this.size; i += 1) {
+      arr.push(ptr.item);
+      ptr = ptr.prev;
+    }
+    return {
+      ...(this.state),
+      items: arr,
+    };
+  }
+}
+
+class Stats {
+  // config (all fields are optional):
+  // -----
+  // pathDepth: how many path segments to track
+  //   0: all the paths are tracked together
+  //   1: stats are cummulated at 1st path segment (e.g. /auth/google and /auth/facebook will be tracked under /auth)
+  //   2: ... cummulated at 2nd path segment
+  //   ...
+  //   -1 (default): all path segments are used (no cummulation)
+  //
+  // beforeCb: (ctx) => {}, callback to invoke before executing next() middleware
+  //
+  // afterCb: (ctx, durationMs) => {}, callback to invoke after next() middleware returns
+  //   providing millisecond duration as 2nd argument to the callback call (handy for logging!)
+  //
+  // pathWhitelist: array of paths (regular expressions) that are to be tracked, all paths are tracked by default
+  //
+  // pathBlacklist: array of paths (regular expressions) that should be excluded from tracking, none by default
+  //
+  // recentStats: how many recent individual calls to track, 32 by default
+  constructor(config) {
+    this.config = {
+      pathDepth: (typeof config.pathDepth === 'number') ? config.pathDepth : -1,
+      beforeCb: (typeof config.beforeCb === 'function') ? config.beforeCb : () => {},
+      afterCb: (typeof config.afterCb === 'function') ? config.afterCb : () => {},
+      pathWhitelist: (typeof config.pathWhitelist === 'object') ? config.pathWhitelist : [/\/.*/],
+      pathBlacklist: (typeof config.pathBlacklist === 'object') ? config.pathBlacklist : [],
+      recentStats: (typeof config.recentStats === 'number') ? config.recentStats : 32,
+    };
+    if (this.config.recentStats < 1) { this.config.recentStats = 1; }
+    this.data = {
+      startedAt: Date.now(),
+      stats: {},
+    };
+    this.update = this.update.bind(this);
+  }
+
+  // koa middleware to process statictics for given request / response exchange
+  async update(ctx, next) {
+    this.config.beforeCb(ctx);
+    const start = Date.now();
+    await next();
+    const durationMs = Date.now() - start;
+    this.config.afterCb(ctx, durationMs);
+    const key = this.getTrackingKey(ctx.path);
+    if (key) {
+      const stats = this.data.stats[key] || {};
+      const statsPerStatus = stats[ctx.status] || new StatefulRingBuffer(
+        this.config.recentStats,
+        { count: 0, sum: 0, sum2: 0 },
+        (state, elem) => ({
+          count: state.count + 1,
+          sum: state.sum + elem.duration,
+          sum2: state.sum2 + elem.duration * elem.duration,
+        }),
+      );
+      statsPerStatus.push({
+        ts: start,
+        duration: durationMs,
+      });
+      stats[ctx.status] = statsPerStatus;
+      this.data.stats[key] = stats;
+    }
+  }
+
+  // return tracking key (in case we want to track the path, or `null` in case we don't
+  getTrackingKey(path) {
+    if (!this.config.pathWhitelist.length) { return null; }
+    const white = this.config.pathWhitelist.find((rx) => (rx.test(path)));
+    if (!white) { return null; }
+    const black = this.config.pathBlacklist.find((rx) => (rx.test(path)));
+    if (black) { return null; }
+    if (this.config.pathDepth === -1) { return path; }
+    const segments = path.split('/');
+    segments.shift(); // each path starts with leading slash (/)
+    const trimmed = segments.slice(0, this.config.pathDepth);
+    if (trimmed.length < segments.length) { trimmed.push('*'); }
+    return `/${trimmed.join('/')}`;
+  }
+
+  // return collected statistics
+  get(includeRecentStats = false, resetStats = false) {
+    const result = {
+      startedAt: this.data.startedAt,
+      stats: {},
+    };
+    const { stats } = this.data;
+    Object.keys(stats).forEach((path) => {
+      result.stats[path] = {};
+      const pathStats = stats[path];
+      Object.keys(pathStats).forEach((status) => {
+        const raw = stats[path][status].getState(includeRecentStats);
+        const mean = raw.sum / raw.count;
+        const std = Math.sqrt(raw.sum2 / raw.count - mean * mean);
+        const res = {
+          count: raw.count,
+          mean: parseFloat(mean.toFixed(2)),
+          std: parseFloat(std.toFixed(2)),
+        };
+        if (raw.items) { res.items = raw.items; }
+        result.stats[path][status] = res;
+      });
+    });
+    if (resetStats) { this.reset(); }
+    return result;
+  }
+
+  reset() {
+    this.data = {
+      startedAt: Date.now(),
+      stats: {},
+    };
+  }
+}
+
+module.exports = {
+  Stats,
+};

--- a/api-server/package-lock.json
+++ b/api-server/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "siros-postgres",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/api-server/package.json
+++ b/api-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siros-postgres",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Siros API server",
   "main": "server.js",
   "scripts": {

--- a/build-scripts/build-admin-scripts.sh
+++ b/build-scripts/build-admin-scripts.sh
@@ -7,11 +7,11 @@ npm prune --production
 mkdir -p ../build
 rm -f ../build/siros-admin-scripts*.tgz
 PACKAGE_NIX="siros-admin-scripts@${npm_package_version}-nix.tgz"
-PACKAGE_WIN="siros-admin-scripts@${npm_package_version}-win.tgz"
+PACKAGE_WIN="siros-admin-scripts@${npm_package_version}-win.zip"
 echo "creating $PACKAGE_NIX ..."
 COPYFILE_DISABLE=1 tar cfz ../build/$PACKAGE_NIX --exclude='bin/siros*.cmd' bin/siros* fonts images lib scripts node_modules
 echo "... done" && echo ""
 echo "creating $PACKAGE_WIN ..."
-COPYFILE_DISABLE=1 tar cfz ../build/$PACKAGE_WIN bin/siros*.cmd fonts images lib scripts node_modules
+COPYFILE_DISABLE=1 zip -r ../build/$PACKAGE_WIN bin/siros*.cmd fonts images lib scripts node_modules 1>/dev/null
 echo "... done" && echo ""
 npm install --no-production

--- a/db-schema/package-lock.json
+++ b/db-schema/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "siros-postgres",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/db-schema/package.json
+++ b/db-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siros-postgres",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Siros DB schema",
   "dependencies": {
     "dotenv": "^6.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "siros-postgres",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siros-postgres",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "New generation of HW / budget tracking system",
   "scripts": {
     "build": "./build-scripts/build.sh",

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siros-postgres",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Siros Web client",
   "private": true,
   "scripts": {

--- a/web-client/src/version.js
+++ b/web-client/src/version.js
@@ -1,1 +1,1 @@
-export const version = '1.4.1';
+export const version = '1.4.3';


### PR DESCRIPTION
Drop-in koa middleware to provide statistics about request/response code and times.

The middleware is to be used at the beginning of the middleware chain (or as near as it gets) and collects time stats for request/response pairs, grouped by the response code. You can specify what URL paths to monitor and if you want to group the paths (based on the path length, measured in path segments). You can also specify if you want to keep some number of recent measurements as part of the stats.

The main class is api-server/lib/stats.js:57. Once created, its `update` method is the middleware itself. There is function `get` to get the statistics and `reset` to reset them.

Getting the stats is hooked to new endpoint (/api/v1/stats) for me to be able to test the idea (it is running on siros.salsitasoft.com), but this is not necessary for the middleware (I could have dumped the stats once a day into the logfile as well).