### PR TITLE
Increase initial budget and refreshment for part-timers

### DIFF
--- a/admin-scripts/lib/budget-updates.js
+++ b/admin-scripts/lib/budget-updates.js
@@ -15,11 +15,9 @@ const getBudgetUpdates = (user, history, today) => {
       });
     }
   }
-  // when do the yearly refreshes start?
-  const offset = rule.name === config.budget.names.PERIOD2 ? 2 : 1;
   const startDate = user.start_date.split('-');
   const lastRecord = (history.length ? history[history.length - 1].date : user.start_date);
-  let year = parseInt(startDate[0], 10) + offset;
+  let year = parseInt(startDate[0], 10) + rule.firstIncreaseYears;
   let anniversary = `${year}-${startDate[1]}-${startDate[2]}`;
   while (anniversary <= today) {
     if (anniversary > lastRecord) {

--- a/admin-scripts/lib/budget-updates.spec.js
+++ b/admin-scripts/lib/budget-updates.spec.js
@@ -4,6 +4,8 @@ const dates = [
   '02-15',
   '04-01',
   '06-15',
+  '07-13',
+  '07-14',
   '08-01',
   '10-15',
 ];
@@ -12,6 +14,7 @@ const years = [
   2013,
   2015,
   2019,
+  2021,
   2025,
 ];
 
@@ -25,7 +28,19 @@ years.forEach((y) => {
     const resultsPart = [];
     const resultsFull = [];
     let yy;
-    if (date >= '2019-08-01') {
+    if (date >= '2021-07-13') {
+      resultsPart.push({
+        action: 'initial',
+        amount: 55000,
+        date,
+      });
+      resultsFull.push({
+        action: 'initial',
+        amount: 65000,
+        date,
+      });
+      yy = y + 2;
+    } else if (date >= '2019-08-01') {
       resultsPart.push({
         action: 'initial',
         amount: 32500,
@@ -55,14 +70,24 @@ years.forEach((y) => {
     while (yy < STOP_YEAR) {
       const act = `${yy}-${d}`;
       if (act >= '2015-04-01') {
+        let partIncreaseAmount;
+        if (act >= '2021-07-13') {
+          partIncreaseAmount = 21000;
+        } else if (act >= '2019-08-01') {
+          partIncreaseAmount = 12500;
+        } else {
+          partIncreaseAmount = 11250;
+        }
+        const fullIncreaseAmount = act >= '2019-08-01' ? 25000 : 22500;
+
         resultsPart.push({
           action: 'yearly',
-          amount: (act >= '2019-08-01' ? 12500 : 11250),
+          amount: partIncreaseAmount,
           date: act,
         });
         resultsFull.push({
           action: 'yearly',
-          amount: (act >= '2019-08-01' ? 25000 : 22500),
+          amount: fullIncreaseAmount,
           date: act,
         });
       }

--- a/admin-scripts/lib/budget-updates.spec.js
+++ b/admin-scripts/lib/budget-updates.spec.js
@@ -4,8 +4,7 @@ const dates = [
   '02-15',
   '04-01',
   '06-15',
-  '07-13',
-  '07-14',
+  '07-31',
   '08-01',
   '10-15',
 ];
@@ -28,7 +27,7 @@ years.forEach((y) => {
     const resultsPart = [];
     const resultsFull = [];
     let yy;
-    if (date >= '2021-07-13') {
+    if (date >= '2021-08-01') {
       resultsPart.push({
         action: 'initial',
         amount: 55000,
@@ -71,7 +70,7 @@ years.forEach((y) => {
       const act = `${yy}-${d}`;
       if (act >= '2015-04-01') {
         let partIncreaseAmount;
-        if (act >= '2021-07-13') {
+        if (act >= '2021-08-01') {
           partIncreaseAmount = 21000;
         } else if (act >= '2019-08-01') {
           partIncreaseAmount = 12500;

--- a/admin-scripts/lib/config.js
+++ b/admin-scripts/lib/config.js
@@ -55,7 +55,7 @@ const config = {
         },
         name: budgetNames.PERIOD2,
         firstIncreaseYears: 2,
-        validUntil: '2021-07-13',
+        validUntil: '2021-08-01',
       },
       {
         initial: {

--- a/admin-scripts/lib/config.js
+++ b/admin-scripts/lib/config.js
@@ -2,6 +2,7 @@ const budgetNames = {
   PERIOD0: 'period0',
   PERIOD1: 'period1',
   PERIOD2: 'period2',
+  PERIOD3: 'period3',
 };
 
 const budgetStartDate = '2015-04-01'; // when the budget calculation starts
@@ -23,6 +24,7 @@ const config = {
           partTime: 0,
         },
         name: budgetNames.PERIOD0,
+        firstIncreaseYears: 1,
         validUntil: budgetStartDate,
       },
       {
@@ -37,6 +39,7 @@ const config = {
           partTime: 11250,
         },
         name: budgetNames.PERIOD1,
+        firstIncreaseYears: 1,
         validUntil: '2019-08-01',
       },
       {
@@ -51,6 +54,22 @@ const config = {
           partTime: 12500,
         },
         name: budgetNames.PERIOD2,
+        firstIncreaseYears: 2,
+        validUntil: '2021-07-13',
+      },
+      {
+        initial: {
+          // initial budget
+          fullTime: 65000,
+          partTime: 55000,
+        },
+        yearly: {
+          // yearly increase
+          fullTime: 25000,
+          partTime: 21000,
+        },
+        name: budgetNames.PERIOD3,
+        firstIncreaseYears: 2,
         validUntil: '2999-12-31',
       },
     ],


### PR DESCRIPTION
As agreed, part-timers will get following:
- initial budget: 55K
- yearly increase: 21K

The rule of first increase being added after two years stays in tact. The PR only changes the way how this information is stored in the config.